### PR TITLE
ruffle xml support: accept invalid references and standalone '&'

### DIFF
--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -180,7 +180,7 @@ fn issue_93_large_characters_in_entity_references() {
         r#"<hello>&𤶼;</hello>"#.as_bytes(),
         r#"
             |StartElement(hello)
-            |1:10 FailedUnescape([38, 240, 164, 182, 188, 59]; Error while escaping character at range 1..5: Unrecognized escape symbol: Ok("𤶼"))
+            |Characters(&𤶼;)
             |EndElement(hello)
             |EndDocument
         "#


### PR DESCRIPTION
(This could have been easier if `memchr2_iter` was copyable, then I could have just kept the original implementation and copied the iterator to effectively "`peek()`" it. As it is, I needed to rewrite entire implementation to a state machine.)

~~This is experimental - as in, I haven't actually tested this in Ruffle yet. This doesn't block review, but blocks merge and integration with Ruffle itself.~~ Tested in Ruffle, the relevant issue https://github.com/ruffle-rs/ruffle/issues/4699 is fixed. I'm gonna experiment some more with Flash and add more tests though.